### PR TITLE
Add logToSyslog option for journald/syslog logging

### DIFF
--- a/lancache.nix
+++ b/lancache.nix
@@ -117,10 +117,28 @@ with lib.options;
 
       # TODO: might have to create this
       logPrefix = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
         default = null;
         description = ''
-          Sets the location to put the cached data in
+          Directory for lancache log files (access, error, upstream, stream).
+          Must be set when logToSyslog is false.
+        '';
+      };
+
+      logToSyslog = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Send all nginx log output to syslog instead of files.
+          On systemd-based systems (e.g. NixOS), journald captures syslog
+          messages automatically, so logs appear in `journalctl`.
+
+          Different nginx contexts use distinct syslog tags for filtering:
+          - `lancache` (primary cache engine)
+          - `lancache-upstream` (upstream redirect handler)
+          - `lancache-stream` (TLS SNI passthrough)
+
+          When this is true, logPrefix is not used.
         '';
       };
 
@@ -181,6 +199,46 @@ with lib.options;
   config =
     let
       cfg = config.services.lancache;
+
+      # Syslog targets with distinct tags per nginx context
+      syslogTarget =
+        tag: "syslog:server=unix:/dev/log,facility=local6,tag=${tag}";
+
+      genericAccessLog =
+        if cfg.logToSyslog then
+          "${syslogTarget "lancache"} cachelog"
+        else
+          "${cfg.logPrefix}/access.log cachelog";
+
+      genericErrorLog =
+        if cfg.logToSyslog then
+          syslogTarget "lancache"
+        else
+          "${cfg.logPrefix}/error.log";
+
+      upstreamAccessLog =
+        if cfg.logToSyslog then
+          "${syslogTarget "lancache-upstream"} ${cfg.logFormat}"
+        else
+          "${cfg.logPrefix}/upstream-access.log ${cfg.logFormat}";
+
+      upstreamErrorLog =
+        if cfg.logToSyslog then
+          syslogTarget "lancache-upstream"
+        else
+          "${cfg.logPrefix}/upstream-error.log";
+
+      streamAccessLog =
+        if cfg.logToSyslog then
+          "${syslogTarget "lancache-stream"} stream_basic"
+        else
+          "${cfg.logPrefix}/stream-access.log stream_basic";
+
+      streamErrorLog =
+        if cfg.logToSyslog then
+          syslogTarget "lancache-stream"
+        else
+          "${cfg.logPrefix}/stream-error.log";
 
       isNonEmpty = (
         domain:
@@ -262,6 +320,16 @@ with lib.options;
     lib.mkIf cfg.enable
 
       {
+        assertions = [
+          {
+            assertion = cfg.logToSyslog || cfg.logPrefix != null;
+            message = ''
+              services.lancache: either set logPrefix (for file-based logging)
+              or set logToSyslog = true (for syslog/journald logging).
+            '';
+          }
+        ];
+
         services.lancache.domainIndex = index;
 
         # TODO: only add this if this isn't a path nginx can write to
@@ -363,8 +431,8 @@ with lib.options;
 
             extraConfig = # nginx
               ''
-                access_log ${cfg.logPrefix}/access.log cachelog;
-                error_log ${cfg.logPrefix}/error.log;
+                access_log ${genericAccessLog};
+                error_log ${genericErrorLog};
 
                 # sites-available/cache.conf.d/10_root.conf
                 resolver ${cfg.upstreamDns} ipv6=off;
@@ -542,8 +610,8 @@ with lib.options;
                 ''
                   # No access_log tracking as all requests to this instance are already logged through monolithic
 
-                  access_log ${cfg.logPrefix}/upstream-access.log ${cfg.logFormat};
-                  error_log ${cfg.logPrefix}/upstream-error.log;
+                  access_log ${upstreamAccessLog};
+                  error_log ${upstreamErrorLog};
 
                   #include /etc/nginx/sites-available/upstream.conf.d/*.conf;
                   #10_resolver.conf
@@ -614,8 +682,8 @@ with lib.options;
                   proxy_pass  $ssl_preread_server_name:443;
                   ssl_preread on;
 
-                  access_log ${cfg.logPrefix}/stream-access.log stream_basic;
-                  error_log ${cfg.logPrefix}/stream-error.log;
+                  access_log ${streamAccessLog};
+                  error_log ${streamErrorLog};
                 }
             '';
         };

--- a/lancache.nix
+++ b/lancache.nix
@@ -135,8 +135,8 @@ with lib.options;
 
           Different nginx contexts use distinct syslog tags for filtering:
           - `lancache` (primary cache engine)
-          - `lancache-upstream` (upstream redirect handler)
-          - `lancache-stream` (TLS SNI passthrough)
+          - `lancache_upstream` (upstream redirect handler)
+          - `lancache_stream` (TLS SNI passthrough)
 
           When this is true, logPrefix is not used.
         '';
@@ -218,25 +218,25 @@ with lib.options;
 
       upstreamAccessLog =
         if cfg.logToSyslog then
-          "${syslogTarget "lancache-upstream"} ${cfg.logFormat}"
+          "${syslogTarget "lancache_upstream"} ${cfg.logFormat}"
         else
           "${cfg.logPrefix}/upstream-access.log ${cfg.logFormat}";
 
       upstreamErrorLog =
         if cfg.logToSyslog then
-          syslogTarget "lancache-upstream"
+          syslogTarget "lancache_upstream"
         else
           "${cfg.logPrefix}/upstream-error.log";
 
       streamAccessLog =
         if cfg.logToSyslog then
-          "${syslogTarget "lancache-stream"} stream_basic"
+          "${syslogTarget "lancache_stream"} stream_basic"
         else
           "${cfg.logPrefix}/stream-access.log stream_basic";
 
       streamErrorLog =
         if cfg.logToSyslog then
-          syslogTarget "lancache-stream"
+          syslogTarget "lancache_stream"
         else
           "${cfg.logPrefix}/stream-error.log";
 

--- a/lancache.nix
+++ b/lancache.nix
@@ -200,45 +200,51 @@ with lib.options;
     let
       cfg = config.services.lancache;
 
-      # Syslog targets with distinct tags per nginx context
-      syslogTarget =
-        tag: "syslog:server=unix:/dev/log,facility=local6,tag=${tag}";
+      # Build access_log / error_log targets for each nginx context.
+      # When logToSyslog is enabled, logs go to syslog with a per-context tag;
+      # otherwise they go to files under logPrefix.
+      logTarget =
+        {
+          tag,
+          accessFile,
+          errorFile,
+          format ? null,
+        }:
+        let
+          syslog = "syslog:server=unix:/dev/log,facility=local6,tag=${tag}";
+          fmtSuffix = lib.optionalString (format != null) " ${format}";
+        in
+        {
+          access =
+            if cfg.logToSyslog then
+              "${syslog}${fmtSuffix}"
+            else
+              "${cfg.logPrefix}/${accessFile}${fmtSuffix}";
+          error =
+            if cfg.logToSyslog then
+              syslog
+            else
+              "${cfg.logPrefix}/${errorFile}";
+        };
 
-      genericAccessLog =
-        if cfg.logToSyslog then
-          "${syslogTarget "lancache"} cachelog"
-        else
-          "${cfg.logPrefix}/access.log cachelog";
-
-      genericErrorLog =
-        if cfg.logToSyslog then
-          syslogTarget "lancache"
-        else
-          "${cfg.logPrefix}/error.log";
-
-      upstreamAccessLog =
-        if cfg.logToSyslog then
-          "${syslogTarget "lancache_upstream"} ${cfg.logFormat}"
-        else
-          "${cfg.logPrefix}/upstream-access.log ${cfg.logFormat}";
-
-      upstreamErrorLog =
-        if cfg.logToSyslog then
-          syslogTarget "lancache_upstream"
-        else
-          "${cfg.logPrefix}/upstream-error.log";
-
-      streamAccessLog =
-        if cfg.logToSyslog then
-          "${syslogTarget "lancache_stream"} stream_basic"
-        else
-          "${cfg.logPrefix}/stream-access.log stream_basic";
-
-      streamErrorLog =
-        if cfg.logToSyslog then
-          syslogTarget "lancache_stream"
-        else
-          "${cfg.logPrefix}/stream-error.log";
+      genericLog = logTarget {
+        tag = "lancache";
+        accessFile = "access.log";
+        errorFile = "error.log";
+        format = "cachelog";
+      };
+      upstreamLog = logTarget {
+        tag = "lancache_upstream";
+        accessFile = "upstream-access.log";
+        errorFile = "upstream-error.log";
+        format = cfg.logFormat;
+      };
+      streamLog = logTarget {
+        tag = "lancache_stream";
+        accessFile = "stream-access.log";
+        errorFile = "stream-error.log";
+        format = "stream_basic";
+      };
 
       isNonEmpty = (
         domain:
@@ -431,8 +437,8 @@ with lib.options;
 
             extraConfig = # nginx
               ''
-                access_log ${genericAccessLog};
-                error_log ${genericErrorLog};
+                access_log ${genericLog.access};
+                error_log ${genericLog.error};
 
                 # sites-available/cache.conf.d/10_root.conf
                 resolver ${cfg.upstreamDns} ipv6=off;
@@ -610,8 +616,8 @@ with lib.options;
                 ''
                   # No access_log tracking as all requests to this instance are already logged through monolithic
 
-                  access_log ${upstreamAccessLog};
-                  error_log ${upstreamErrorLog};
+                  access_log ${upstreamLog.access};
+                  error_log ${upstreamLog.error};
 
                   #include /etc/nginx/sites-available/upstream.conf.d/*.conf;
                   #10_resolver.conf
@@ -682,8 +688,8 @@ with lib.options;
                   proxy_pass  $ssl_preread_server_name:443;
                   ssl_preread on;
 
-                  access_log ${streamAccessLog};
-                  error_log ${streamErrorLog};
+                  access_log ${streamLog.access};
+                  error_log ${streamLog.error};
                 }
             '';
         };


### PR DESCRIPTION
## Summary

Add a `logToSyslog` boolean option (default `false`) that sends all nginx log output to syslog via the unix socket `/dev/log` instead of files. On systemd-based systems like NixOS, journald captures syslog messages automatically — providing automatic rotation, structured querying via `journalctl`, and eliminating the need for logrotate configuration.

### Changes

- **New option `services.lancache.logToSyslog`** — when `true`, all 6 nginx log directives use `syslog:server=unix:/dev/log,facility=local6,tag=<tag>` instead of file paths
- **Changed `logPrefix` type** from `types.str` to `types.nullOr types.str` — allows omitting it when syslog is enabled
- **Added assertion** — ensures at least one logging method (logPrefix or logToSyslog) is configured
- **Refactored log targets** — extracted `logTarget` helper function to reduce duplication across the 6 log directives
- **Per-context syslog tags** for easy filtering:
  - `lancache` — primary cache engine
  - `lancache_upstream` — upstream redirect handler
  - `lancache_stream` — TLS SNI passthrough

### Backward compatibility

- `logToSyslog` defaults to `false` — existing configs are unaffected
- `nullOr str` is a superset of `str` — every existing `logPrefix` value remains valid
- File-based log filenames are preserved exactly (`access.log`, `upstream-access.log`, `stream-access.log`, etc.)

### Usage

```nix
services.lancache = {
  enable = true;
  logToSyslog = true;
  # logPrefix is no longer needed
};
```

Filter logs with:
```bash
journalctl _COMM=nginx --grep="lancache:"
journalctl _COMM=nginx --grep="lancache_upstream:"
journalctl _COMM=nginx --grep="lancache_stream:"
```

## Test plan

- [x] Build NixOS configuration with `logToSyslog = true` — succeeds
- [x] Deploy to NixOS server — nginx starts without errors
- [x] Verify syslog entries appear in journald after HTTP request
- [x] Verify backward compatibility: `logToSyslog = false` with `logPrefix` set produces identical nginx config to upstream